### PR TITLE
Non-awful colors for comment direct-link fade

### DIFF
--- a/packages/lesswrong/styles/_comments.scss
+++ b/packages/lesswrong/styles/_comments.scss
@@ -14,7 +14,7 @@ $ea-blue: #0c869b;
     background: #00B2BE;
   }
   to {
-    background: #1B5266;
+    background: rgba(255, 255, 255, 0);
   }
 }
 


### PR DESCRIPTION
Should fade to zero opacity, not to a color almost as dark as the text. Soon LW will rework the comment linking and obsolete the fix, but what can you do.