### PR TITLE
[hotfix] Fix email set to null error

### DIFF
--- a/packages/lesswrong/server/resolvers/userResolvers.ts
+++ b/packages/lesswrong/server/resolvers/userResolvers.ts
@@ -79,7 +79,7 @@ addGraphQLResolvers({
           username,
           displayName: username,
           slug: await Utils.getUnusedSlugByCollectionName("Users", slugify(username)),
-          email,
+          ...(email ? {email} : {}),
           subscribedToDigest: subscribeToDigest
         },
         // We've already done necessary gating


### PR DESCRIPTION
I could have sworn I tested this exact case, but I think I must have missed the email being null even though _emails_ was still set. Error occurs because even if we don't put email in the mutation on the frontend, apollo fills it in as null, and then when performing the update, we have {email: null} in the update.