### PR TITLE
hide past events and only show nearby in-person events

### DIFF
--- a/packages/lesswrong/components/localGroups/CommunityHome.tsx
+++ b/packages/lesswrong/components/localGroups/CommunityHome.tsx
@@ -71,10 +71,15 @@ const CommunityHome = ({classes}: {
     const filters = query?.filters || [];
     const { SingleColumnSection, SectionTitle, PostsList2, GroupFormLink, SectionFooter, Typography, SectionButton } = Components
 
-    const eventsListTerms = {
+    const eventsListTerms = currentUserLocation.known ? {
       view: 'nearbyEvents',
       lat: currentUserLocation.lat,
       lng: currentUserLocation.lng,
+      limit: 5,
+      filters: filters,
+      onlineEvent: false
+    } : {
+      view: 'events',
       limit: 5,
       filters: filters,
       onlineEvent: false

--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -821,7 +821,7 @@ Posts.addView("onlineEvents", (terms: PostsViewTerms) => {
       onlineEvent: true,
       isEvent: true,
       groupId: null,
-      $or: [{startTime: {$exists: false}}, {startTime: {$gt: new Date()}}, {endTime: {$gt: new Date()}}],
+      $or: [{startTime: {$gt: new Date()}}, {endTime: {$gt: new Date()}}],
     },
     options: {
       sort: {
@@ -846,7 +846,7 @@ Posts.addView("nearbyEvents", (terms: PostsViewTerms) => {
       groupId: null,
       isEvent: true,
       onlineEvent: onlineEvent,
-      $or: [{startTime: {$exists: false}}, {startTime: {$gt: new Date()}}, {endTime: {$gt: new Date()}}],
+      $or: [{startTime: {$gt: new Date()}}, {endTime: {$gt: new Date()}}],
       mongoLocation: {
         $near: {
           $geometry: {
@@ -887,12 +887,11 @@ Posts.addView("events", (terms: PostsViewTerms) => {
       createdAt: {$gte: twoMonthsAgo},
       groupId: terms.groupId ? terms.groupId : null,
       baseScore: {$gte: 1},
-      $or: [{startTime: {$exists: false}}, {startTime: {$gt: new Date()}}, {endTime: {$gt: new Date()}}],
+      $or: [{startTime: {$gt: new Date()}}, {endTime: {$gt: new Date()}}],
     },
     options: {
       sort: {
-        baseScore: -1,
-        startTime: -1,
+        startTime: 1
       }
     }
   }


### PR DESCRIPTION
This PR makes a few improvements to the In-Person Events list:
1. We no longer show events that have already ended
2. We limit the list to events within ~50 miles of the user, and order the events chronologically (previously we ordered by proximity to the user)
3. If the user doesn't provide a location, we list all upcoming events chronologically (excluding those without a start time)

<img width="500" alt="Screen Shot 2021-10-14 at 3 36 05 PM" src="https://user-images.githubusercontent.com/9057804/137383992-2e12c359-51b4-4aec-920f-d7b124d9e292.png">
